### PR TITLE
feat: display server tile/pixel coordinates

### DIFF
--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -9,3 +9,7 @@ export function uniqueName(base: string, existing: string[]) {
   while (names.has(`${base} (${i})`.toLowerCase())) i++;
   return `${base} (${i})`;
 }
+
+export function serverTPtoDisplayTP(tile: number[], pixel: number[]) {
+  return [((tile[0] % 4) * 1000) + pixel[0], ((tile[1] % 4) * 1000) + pixel[1]];
+}

--- a/src/ui/coordDisplay.ts
+++ b/src/ui/coordDisplay.ts
@@ -1,0 +1,22 @@
+import { serverTPtoDisplayTP } from '../core/util';
+
+export function updatePixelCoords(chunk1: number, chunk2: number, posX: number, posY: number) {
+  const displayTP = serverTPtoDisplayTP([chunk1, chunk2], [posX, posY]);
+  const spans = document.querySelectorAll('span');
+  for (const el of spans) {
+    if (el.textContent?.trim().includes(`${displayTP[0]}, ${displayTP[1]}`)) {
+      let display = document.getElementById('op-display-coords');
+      const text = `(Tl X: ${chunk1}, Tl Y: ${chunk2}, Px X: ${posX}, Px Y: ${posY})`;
+      if (!display) {
+        display = document.createElement('span');
+        display.id = 'op-display-coords';
+        display.textContent = text;
+        (display.style as any).marginLeft = 'calc(var(--spacing)*3)';
+        display.style.fontSize = 'small';
+        el.parentNode?.parentNode?.parentNode?.insertAdjacentElement('afterend', display);
+      } else {
+        display.textContent = text;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- convert server tile/pixel coords to display coordinates
- show `(Tl X/Tl Y, Px X/Px Y)` near clicked pixel
- always hook fetch to watch pixel requests and update coord display

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1bb865c14832da8dbda75ff7d84f6