### PR TITLE
Show global coordinates for intercepted pixel

### DIFF
--- a/src/core/hook.ts
+++ b/src/core/hook.ts
@@ -2,6 +2,7 @@
 import { NATIVE_FETCH } from './gm';
 import { config, saveConfig } from './store';
 import { matchTileUrl, matchPixelUrl, extractPixelCoords, buildOverlayDataForChunkUnified, composeTileUnified } from './overlay';
+import { updatePixelCoords } from '../ui/coordDisplay';
 import { emit, EV_ANCHOR_SET, EV_AUTOCAP_CHANGED } from './events';
 
 let hookInstalled = false;
@@ -32,31 +33,34 @@ export function attachHook() {
   const hookedFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     const urlStr = typeof input === 'string' ? input : ((input as Request).url) || '';
 
+    const pixelMatch = matchPixelUrl(urlStr);
+    if (pixelMatch) {
+      const c = extractPixelCoords(pixelMatch.normalized);
+      updatePixelCoords(c.chunk1, c.chunk2, c.posX, c.posY);
+    }
+
     // Anchor auto-capture: watch pixel endpoint, then store/normalize
-    if (config.autoCapturePixelUrl && config.activeOverlayId) {
-      const pixelMatch = matchPixelUrl(urlStr);
-      if (pixelMatch) {
-        const ov = config.overlays.find(o => o.id === config.activeOverlayId);
-        if (ov) {
-          const changed = (ov.pixelUrl !== pixelMatch.normalized);
-          if (changed) {
-            ov.pixelUrl = pixelMatch.normalized;
-            ov.offsetX = 0; ov.offsetY = 0;
-            await saveConfig(['overlays']);
+    if (pixelMatch && config.autoCapturePixelUrl && config.activeOverlayId) {
+      const ov = config.overlays.find(o => o.id === config.activeOverlayId);
+      if (ov) {
+        const changed = (ov.pixelUrl !== pixelMatch.normalized);
+        if (changed) {
+          ov.pixelUrl = pixelMatch.normalized;
+          ov.offsetX = 0; ov.offsetY = 0;
+          await saveConfig(['overlays']);
 
-            // turn off autocapture and notify UI (via events)
-            config.autoCapturePixelUrl = false;
-            await saveConfig(['autoCapturePixelUrl']);
+          // turn off autocapture and notify UI (via events)
+          config.autoCapturePixelUrl = false;
+          await saveConfig(['autoCapturePixelUrl']);
 
-            // keep legacy callback for any existing wiring
-            updateUICallback?.();
+          // keep legacy callback for any existing wiring
+          updateUICallback?.();
 
-            const c = extractPixelCoords(ov.pixelUrl);
-            emit(EV_ANCHOR_SET, { overlayId: ov.id, name: ov.name, chunk1: c.chunk1, chunk2: c.chunk2, posX: c.posX, posY: c.posY });
-            emit(EV_AUTOCAP_CHANGED, { enabled: false });
+          const c = extractPixelCoords(ov.pixelUrl);
+          emit(EV_ANCHOR_SET, { overlayId: ov.id, name: ov.name, chunk1: c.chunk1, chunk2: c.chunk2, posX: c.posX, posY: c.posY });
+          emit(EV_AUTOCAP_CHANGED, { enabled: false });
 
-            ensureHook(); // reevaluate whether hook is still needed after capture
-          }
+          ensureHook(); // reevaluate whether hook is still needed after capture
         }
       }
     }

--- a/src/ui/coordDisplay.ts
+++ b/src/ui/coordDisplay.ts
@@ -1,0 +1,27 @@
+/// <reference types="tampermonkey" />
+
+export function updatePixelCoords(chunk1: number, chunk2: number, posX: number, posY: number) {
+  const conv = (unsafeWindow as any)?.serverTPtoDisplayTP?.(chunk1, chunk2, posX, posY);
+  if (!conv) return;
+
+  const tlX = conv.chunk1 ?? 0;
+  const tlY = conv.chunk2 ?? 0;
+  const pxX = conv.posX ?? 0;
+  const pxY = conv.posY ?? 0;
+
+  let span = document.getElementById('op-display-coords') as HTMLSpanElement | null;
+  if (!span) {
+    span = document.createElement('span');
+    span.id = 'op-display-coords';
+    const pixelLabel = Array.from(document.querySelectorAll('span')).find(el => (el.textContent || '').startsWith('Pixel'));
+    if (pixelLabel && pixelLabel.parentNode) {
+      pixelLabel.parentNode.insertBefore(span, pixelLabel.nextSibling);
+    } else {
+      document.body.appendChild(span);
+    }
+  }
+
+  span.textContent = `(Tl X: ${tlX}, Tl Y: ${tlY}, Px X: ${pxX}, Px Y: ${pxY})`;
+}
+
+export default updatePixelCoords;


### PR DESCRIPTION
## Summary
- display global tile/pixel coordinates next to the canvas pixel info
- trigger coordinate updates whenever a pixel fetch occurs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1d671137c832da860924d68084b6e