### PR TITLE
Optimize symbols overlay drawing

### DIFF
--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -55,7 +55,7 @@ export function createUI() {
             <div class="op-mode-setting" data-setting="minify">
               <div class="op-row"><label>Style</label>
                 <div class="op-row"><input type="radio" name="minify-style" value="dots" id="op-style-dots"><label for="op-style-dots">Dots</label></div>
-                <div class="op-row"><input type="radio" name="minify-style" value="symbols" id="op-style-symbols"><label for="op-style-symbols">Symbols (slow and buggy, wait 4 fix!)</label></div>
+                <div class="op-row"><input type="radio" name="minify-style" value="symbols" id="op-style-symbols"><label for="op-style-symbols">Symbols</label></div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- speed up symbol-style minification by limiting processing to intersecting pixels
- return only the necessary image data region and drop outdated warning from UI

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a24d0f6634832d9a5760bdb7f481a7