### PR TITLE
feat: add copy coords button

### DIFF
--- a/src/ui/coordDisplay.ts
+++ b/src/ui/coordDisplay.ts
@@ -1,3 +1,5 @@
+import { showToast } from '../core/toast';
+
 let target: HTMLElement | null = null;
 let container: HTMLSpanElement | null = null;
 let textEl: HTMLSpanElement | null = null;
@@ -45,7 +47,10 @@ export function updatePixelCoords(chunk1: number, chunk2: number, posX: number, 
   }
 
   if (copyBtn) {
-    copyBtn.onclick = () => navigator.clipboard.writeText(`${chunk1} ${chunk2} ${posX} ${posY}`);
+    copyBtn.onclick = () =>
+      navigator.clipboard
+        .writeText(`${chunk1} ${chunk2} ${posX} ${posY}`)
+        .then(() => showToast('Coordinates copied successfully ✅', 'success'));
   }
 }
 

--- a/src/ui/coordDisplay.ts
+++ b/src/ui/coordDisplay.ts
@@ -1,5 +1,7 @@
 let target: HTMLElement | null = null;
-let display: HTMLSpanElement | null = null;
+let container: HTMLSpanElement | null = null;
+let textEl: HTMLSpanElement | null = null;
+let copyBtn: HTMLButtonElement | null = null;
 
 export function updatePixelCoords(chunk1: number, chunk2: number, posX: number, posY: number) {
   const dispX = ((chunk1 % 4) * 1000) + posX;
@@ -14,14 +16,36 @@ export function updatePixelCoords(chunk1: number, chunk2: number, posX: number, 
 
   if (!target) return;
 
-  if (!display) {
-    display = document.createElement('span');
-    display.id = 'op-display-coords';
-    (display.style as any).marginLeft = 'calc(var(--spacing)*3)';
-    display.style.fontSize = 'small';
-    target.insertAdjacentElement('afterend', display);
+  if (!container) {
+    container = document.createElement('span');
+    container.id = 'op-display-coords';
+    (container.style as any).marginLeft = 'calc(var(--spacing)*3)';
+    container.style.fontSize = 'small';
+
+    textEl = document.createElement('span');
+
+    copyBtn = document.createElement('button');
+    copyBtn.id = 'op-copy-coords';
+    copyBtn.title = 'Copier les coordonnées';
+    copyBtn.style.marginLeft = 'var(--spacing)';
+    copyBtn.style.background = 'none';
+    copyBtn.style.border = 'none';
+    copyBtn.style.cursor = 'pointer';
+    copyBtn.style.padding = '0';
+    copyBtn.innerHTML =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+
+    container.appendChild(textEl);
+    container.appendChild(copyBtn);
+    target.insertAdjacentElement('afterend', container);
   }
 
-  display.textContent = `(Tl X: ${chunk1}, Tl Y: ${chunk2}, Px X: ${posX}, Px Y: ${posY})`;
+  if (textEl) {
+    textEl.textContent = `(Tl X: ${chunk1}, Tl Y: ${chunk2}, Px X: ${posX}, Px Y: ${posY})`;
+  }
+
+  if (copyBtn) {
+    copyBtn.onclick = () => navigator.clipboard.writeText(`${chunk1} ${chunk2} ${posX} ${posY}`);
+  }
 }
 


### PR DESCRIPTION
## Summary
- add copy button with clipboard icon to coordinate display

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2624e2a78832d80ce2e3d035099ba