### PR TITLE
feat: add overlay backup import/export

### DIFF
--- a/src/ui/coordDisplay.ts
+++ b/src/ui/coordDisplay.ts
@@ -1,5 +1,9 @@
+import { showToast } from '../core/toast';
+
 let target: HTMLElement | null = null;
-let display: HTMLSpanElement | null = null;
+let container: HTMLSpanElement | null = null;
+let textEl: HTMLSpanElement | null = null;
+let copyBtn: HTMLButtonElement | null = null;
 
 export function updatePixelCoords(chunk1: number, chunk2: number, posX: number, posY: number) {
   const dispX = ((chunk1 % 4) * 1000) + posX;
@@ -14,14 +18,39 @@ export function updatePixelCoords(chunk1: number, chunk2: number, posX: number, 
 
   if (!target) return;
 
-  if (!display) {
-    display = document.createElement('span');
-    display.id = 'op-display-coords';
-    (display.style as any).marginLeft = 'calc(var(--spacing)*3)';
-    display.style.fontSize = 'small';
-    target.insertAdjacentElement('afterend', display);
+  if (!container) {
+    container = document.createElement('span');
+    container.id = 'op-display-coords';
+    (container.style as any).marginLeft = 'calc(var(--spacing)*3)';
+    container.style.fontSize = 'small';
+
+    textEl = document.createElement('span');
+
+    copyBtn = document.createElement('button');
+    copyBtn.id = 'op-copy-coords';
+    copyBtn.title = 'Copier les coordonnées';
+    copyBtn.style.marginLeft = 'var(--spacing)';
+    copyBtn.style.background = 'none';
+    copyBtn.style.border = 'none';
+    copyBtn.style.cursor = 'pointer';
+    copyBtn.style.padding = '0';
+    copyBtn.innerHTML =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+
+    container.appendChild(textEl);
+    container.appendChild(copyBtn);
+    target.insertAdjacentElement('afterend', container);
   }
 
-  display.textContent = `(Tl X: ${chunk1}, Tl Y: ${chunk2}, Px X: ${posX}, Px Y: ${posY})`;
+  if (textEl) {
+    textEl.textContent = `(Tl X: ${chunk1}, Tl Y: ${chunk2}, Px X: ${posX}, Px Y: ${posY})`;
+  }
+
+  if (copyBtn) {
+    copyBtn.onclick = () =>
+      navigator.clipboard
+        .writeText(`${chunk1} ${chunk2} ${posX} ${posY}`)
+        .then(() => showToast('Coordinates copied successfully ✅', 'success'));
+  }
 }
 

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -101,8 +101,11 @@ export function createUI() {
               <div class="op-row">
                 <button class="op-button" id="op-add-overlay" title="Create a new overlay">+ Add</button>
                 <button class="op-button" id="op-import-overlay" title="Import overlay JSON">Import</button>
+                <button class="op-button" id="op-import-backup" title="Import overlays from file">Import Backup</button>
+                <button class="op-button" id="op-export-selected" title="Export enabled overlays JSON">Export Selected</button>
                 <button class="op-button" id="op-export-overlay" title="Export active overlay JSON">Export</button>
                 <button class="op-chevron" id="op-collapse-list" title="Collapse/Expand">▾</button>
+                <input type="file" id="op-import-file" accept="application/json" style="display:none">
               </div>
             </div>
           </div>
@@ -259,6 +262,23 @@ async function importOverlayFromJSON(jsonText: string) {
   alert(`Import finished. Imported: ${imported}${failed ? `, Failed: ${failed}` : ''}`);
 }
 
+function exportSelectedOverlaysToClipboard() {
+  const selected = config.overlays.filter(o => o.enabled && o.imageUrl && !o.isLocal);
+  if (selected.length === 0) { alert('No enabled overlays can be exported.'); return; }
+  const payload = selected.map(ov => ({
+    version: 1,
+    name: ov.name,
+    imageUrl: ov.imageUrl!,
+    pixelUrl: ov.pixelUrl ?? null,
+    offsetX: ov.offsetX,
+    offsetY: ov.offsetY,
+    opacity: ov.opacity,
+  }));
+  const text = JSON.stringify(payload, null, 2);
+  copyText(text).then(() => alert('Selected overlay JSON copied to clipboard!'))
+    .catch(() => { prompt('Copy the JSON below:', text); });
+}
+
 function exportActiveOverlayToClipboard() {
   const ov = getActiveOverlay();
   if (!ov) { alert('No active overlay selected.'); return; }
@@ -297,6 +317,12 @@ function addEventListeners(panel: HTMLDivElement) {
 
   $('op-add-overlay').addEventListener('click', async () => { try { await addBlankOverlay(); } catch (e) { console.error(e); } });
   $('op-import-overlay').addEventListener('click', async () => { const text = prompt('Paste overlay JSON (single or array):'); if (!text) return; await importOverlayFromJSON(text); });
+  $('op-import-backup').addEventListener('click', () => $('op-import-file').click());
+  $('op-import-file').addEventListener('change', async (e: any) => {
+    const file = e.target.files && e.target.files[0]; e.target.value=''; if (!file) return;
+    try { const text = await file.text(); await importOverlayFromJSON(text); } catch (err) { console.error(err); alert('Failed to import backup.'); }
+  });
+  $('op-export-selected').addEventListener('click', () => exportSelectedOverlaysToClipboard());
   $('op-export-overlay').addEventListener('click', () => exportActiveOverlayToClipboard());
   $('op-collapse-list').addEventListener('click', () => { config.collapseList = !config.collapseList; saveConfig(['collapseList']); updateUI(); });
   $('op-collapse-editor').addEventListener('click', () => { config.collapseEditor = !config.collapseEditor; saveConfig(['collapseEditor']); updateUI(); });
@@ -555,4 +581,8 @@ export function updateUI() {
   const canExport = !!(ov && ov.imageUrl && !ov.isLocal);
   exportBtn.disabled = !canExport;
   exportBtn.title = canExport ? 'Export active overlay JSON' : 'Export disabled for local images';
+  const exportSelBtn = $('op-export-selected') as HTMLButtonElement;
+  const canExportSel = config.overlays.some(o => o.enabled && o.imageUrl && !o.isLocal);
+  exportSelBtn.disabled = !canExportSel;
+  exportSelBtn.title = canExportSel ? 'Export enabled overlays JSON' : 'Export disabled for local images';
 }


### PR DESCRIPTION
## Summary
- add copy button with clipboard icon to coordinate display
- show top-center success toast after copying coordinates
- export all enabled overlays to JSON and import backups from file

## Testing
- `npm test` (fails: Missing script "test")
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2624e2a78832d80ce2e3d035099ba