### PR TITLE
feat: add color filtering controls

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { createUI, updateUI } from './ui/panel';
 import { displayImageFromData } from './core/overlay';
 import { showToast } from './core/toast';
 import { urlToDataURL } from './core/gm';
+import { analyzeImageColors } from './core/colorFilter';
 
 async function applyTemplateFromUrl() {
   const urlParams = new URLSearchParams(window.location.search);
@@ -35,6 +36,7 @@ async function applyTemplateFromUrl() {
     console.log(`Fetching image from: ${imageUrl}`);
     const imageBase64 = await urlToDataURL(imageUrl);
 
+    const colorCounts = await analyzeImageColors(imageBase64);
     const newOverlay = {
       id: crypto.randomUUID(),
       name,
@@ -46,6 +48,8 @@ async function applyTemplateFromUrl() {
       offsetX,
       offsetY,
       opacity,
+      colorCounts,
+      hiddenColors: []
     };
 
     console.log('Adding new overlay from URL template:', newOverlay);

--- a/src/core/colorFilter.ts
+++ b/src/core/colorFilter.ts
@@ -1,0 +1,28 @@
+import { createCanvas, loadImage } from './canvas';
+import { WPLACE_NAMES } from './palette';
+
+export async function analyzeImageColors(base64: string): Promise<Record<string, number>> {
+  const img = await loadImage(base64);
+  const canvas = createCanvas(img.width, img.height) as HTMLCanvasElement;
+  const ctx = canvas.getContext('2d', { willReadFrequently: true })!;
+  ctx.drawImage(img, 0, 0);
+  const data = ctx.getImageData(0, 0, img.width, img.height).data;
+  const counts: Record<string, number> = {};
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i], g = data[i + 1], b = data[i + 2], a = data[i + 3];
+    if (a === 0) continue;
+    if (r === 0xde && g === 0xfa && b === 0xce) continue;
+    const key = `${r},${g},${b}`;
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  return counts;
+}
+
+export function keyToHex(key: string): string {
+  const [r, g, b] = key.split(',').map(n => Number(n));
+  return '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
+}
+
+export function keyToName(key: string): string {
+  return WPLACE_NAMES[key] || keyToHex(key);
+}

--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -145,17 +145,19 @@ export function overlaySignature(ov: {
   offsetX: number,
   offsetY: number,
   opacity: number,
+  hiddenColors?: string[],
 }, isPalettePerfect?: boolean) {
   const imgKey = ov.imageBase64 ? ov.imageBase64.slice(0, 64) + ':' + ov.imageBase64.length : 'none';
   const perfectFlag = isPalettePerfect !== undefined ? (isPalettePerfect ? 'P' : 'I') : 'U';
-  return [imgKey, ov.pixelUrl || 'null', ov.offsetX, ov.offsetY, ov.opacity, perfectFlag].join('|');
+  const hidden = ov.hiddenColors && ov.hiddenColors.length ? ov.hiddenColors.join(',') : '';
+  return [imgKey, ov.pixelUrl || 'null', ov.offsetX, ov.offsetY, ov.opacity, perfectFlag, hidden].join('|');
 }
 
 export async function buildOverlayDataForChunkUnified(
   ov: {
     id: string, name: string, enabled: boolean,
     imageBase64: string | null, pixelUrl: string | null,
-    offsetX: number, offsetY: number, opacity: number
+    offsetX: number, offsetY: number, opacity: number, hiddenColors?: string[]
   },
   targetChunk1: number,
   targetChunk2: number,
@@ -179,6 +181,8 @@ export async function buildOverlayDataForChunkUnified(
 
   const drawX = (base.chunk1 * TILE_SIZE + base.posX + ov.offsetX) - (targetChunk1 * TILE_SIZE);
   const drawY = (base.chunk2 * TILE_SIZE + base.posY + ov.offsetY) - (targetChunk2 * TILE_SIZE);
+
+  const hiddenSet = new Set(ov.hiddenColors || []);
 
   // Check if image is palette-perfect for optimization
   const isPalettePerfect = isPalettePerfectImage(img);
@@ -205,6 +209,10 @@ export async function buildOverlayDataForChunkUnified(
       const r = data[i], g = data[i+1], b = data[i+2], a = data[i+3];
       // Special case for #deface color
       if (r === 0xde && g === 0xfa && b === 0xce) {
+        continue;
+      }
+      if (hiddenSet.has(`${r},${g},${b}`)) {
+        data[i+3] = 0;
         continue;
       }
       if (a > 0) {
@@ -268,6 +276,7 @@ export async function buildOverlayDataForChunkUnified(
 
           // Early exit for transparent or deface pixels
           if (a <= 128 || (r === 0xde && g === 0xfa && b === 0xce)) continue;
+          if (hiddenSet.has(`${r},${g},${b}`)) continue;
 
           let colorIndex: number;
 
@@ -344,6 +353,9 @@ export async function buildOverlayDataForChunkUnified(
         for (let i = 0; i < data.length; i += 4) {
           const a = data[i + 3];
           if (a === 0) continue;
+
+          const r = data[i], g = data[i + 1], b = data[i + 2];
+          if (hiddenSet.has(`${r},${g},${b}`)) { data[i+3] = 0; continue; }
 
           const px = (i / 4) % width;
           const py = Math.floor((i / 4) / width);

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -13,6 +13,8 @@ export type OverlayItem = {
   offsetX: number;
   offsetY: number;
   opacity: number;
+  colorCounts?: Record<string, number> | null;
+  hiddenColors?: string[];
 };
 
 export type Config = {
@@ -28,6 +30,7 @@ export type Config = {
   collapseList: boolean;
   collapseEditor: boolean;
   collapsePositioning: boolean;
+  collapseColorFilter: boolean;
   ccFreeKeys: string[];
   ccPaidKeys: string[];
   ccZoom: number;
@@ -47,6 +50,7 @@ export const config: Config = {
   collapseList: false,
   collapseEditor: false,
   collapsePositioning: false,
+  collapseColorFilter: false,
   ccFreeKeys: DEFAULT_FREE_KEYS.slice(),
   ccPaidKeys: DEFAULT_PAID_KEYS.slice(),
   ccZoom: 1.0,

--- a/src/ui/ccModal.ts
+++ b/src/ui/ccModal.ts
@@ -5,6 +5,7 @@ import { config, saveConfig } from '../core/store';
 import { MAX_OVERLAY_DIM } from '../core/constants';
 import { ensureHook } from '../core/hook';
 import { clearOverlayCache, paletteDetectionCache } from '../core/cache';
+import { analyzeImageColors } from '../core/colorFilter';
 import { showToast } from '../core/toast';
 
 // dispatch when an overlay image is updated
@@ -177,10 +178,12 @@ export function buildCCModal() {
     }
     const dataUrl = cc!.processedCanvas.toDataURL('image/png');
     ov.imageBase64 = dataUrl; ov.imageUrl = null; ov.isLocal = true;
-    
+    ov.colorCounts = await analyzeImageColors(dataUrl);
+    ov.hiddenColors = [];
+
     // Mark the processed image as palette-perfect for optimization
     paletteDetectionCache.set(dataUrl, true);
-    
+
     await saveConfig(['overlays']); clearOverlayCache(); ensureHook();
     emitOverlayChanged();
     const uniqueColors = Object.keys(cc!.lastColorCounts).length;

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -9,6 +9,7 @@ import { extractPixelCoords } from '../core/overlay';
 import { buildCCModal, openCCModal } from './ccModal';
 import { buildRSModal, openRSModal } from './rsModal';
 import { EV_ANCHOR_SET, EV_AUTOCAP_CHANGED } from '../core/events';
+import { analyzeImageColors, keyToHex, keyToName } from '../core/colorFilter';
 
 let panelEl: HTMLDivElement | null = null;
 
@@ -152,6 +153,20 @@ export function createUI() {
             <div class="op-row"><span class="op-muted" id="op-coord-display"></span></div>
           </div>
         </div>
+
+        <div class="op-section" id="op-color-filter-section" style="display:none;">
+          <div class="op-section-title">
+            <div class="op-title-left">
+              <span class="op-title-text">Color Filter</span>
+            </div>
+            <div class="op-title-right">
+              <button class="op-chevron" id="op-collapse-color-filter" title="Collapse/Expand">▾</button>
+            </div>
+          </div>
+          <div id="op-color-filter-body">
+            <div class="op-color-list" id="op-color-filter-list"></div>
+          </div>
+        </div>
       </div>
   `;
   document.body.appendChild(panel);
@@ -207,7 +222,7 @@ function rebuildOverlayListUI() {
 
 async function addBlankOverlay() {
   const name = uniqueName('Overlay', config.overlays.map(o => o.name || ''));
-  const ov = { id: uid(), name, enabled: true, imageUrl: null, imageBase64: null, isLocal: false, pixelUrl: null, offsetX: 0, offsetY: 0, opacity: 0.7 };
+  const ov = { id: uid(), name, enabled: true, imageUrl: null, imageBase64: null, isLocal: false, pixelUrl: null, offsetX: 0, offsetY: 0, opacity: 0.7, colorCounts: null, hiddenColors: [] };
   config.overlays.push(ov);
   config.activeOverlayId = ov.id;
   await saveConfig(['overlays', 'activeOverlayId']);
@@ -218,6 +233,8 @@ async function addBlankOverlay() {
 async function setOverlayImageFromURL(ov: any, url: string) {
   const base64 = await urlToDataURL(url);
   ov.imageUrl = url; ov.imageBase64 = base64; ov.isLocal = false;
+  ov.colorCounts = await analyzeImageColors(base64);
+  ov.hiddenColors = [];
   await saveConfig(['overlays']); clearOverlayCache();
   config.autoCapturePixelUrl = true; await saveConfig(['autoCapturePixelUrl']);
   ensureHook(); updateUI();
@@ -228,6 +245,8 @@ async function setOverlayImageFromFile(ov: any, file: File) {
   if (!confirm('Local PNGs cannot be exported to friends! Are you sure?')) return;
   const base64 = await fileToDataURL(file);
   ov.imageBase64 = base64; ov.imageUrl = null; ov.isLocal = true;
+  ov.colorCounts = await analyzeImageColors(base64);
+  ov.hiddenColors = [];
   await saveConfig(['overlays']); clearOverlayCache();
   config.autoCapturePixelUrl = true; await saveConfig(['autoCapturePixelUrl']);
   ensureHook(); updateUI();
@@ -248,7 +267,8 @@ async function importOverlayFromJSON(jsonText: string) {
     if (!imageUrl) { failed++; continue; }
     try {
       const base64 = await urlToDataURL(imageUrl);
-      const ov = { id: uid(), name, enabled: true, imageUrl, imageBase64: base64, isLocal: false, pixelUrl, offsetX, offsetY, opacity };
+      const colorCounts = await analyzeImageColors(base64);
+      const ov = { id: uid(), name, enabled: true, imageUrl, imageBase64: base64, isLocal: false, pixelUrl, offsetX, offsetY, opacity, colorCounts, hiddenColors: [] };
       config.overlays.push(ov); imported++;
     } catch (e) { console.error('Import failed for', imageUrl, e); failed++; }
   }
@@ -300,6 +320,7 @@ function addEventListeners(panel: HTMLDivElement) {
   $('op-export-overlay').addEventListener('click', () => exportActiveOverlayToClipboard());
   $('op-collapse-list').addEventListener('click', () => { config.collapseList = !config.collapseList; saveConfig(['collapseList']); updateUI(); });
   $('op-collapse-editor').addEventListener('click', () => { config.collapseEditor = !config.collapseEditor; saveConfig(['collapseEditor']); updateUI(); });
+  $('op-collapse-color-filter').addEventListener('click', () => { config.collapseColorFilter = !config.collapseColorFilter; saveConfig(['collapseColorFilter']); updateUI(); });
   $('op-collapse-positioning').addEventListener('click', () => { config.collapsePositioning = !config.collapsePositioning; saveConfig(['collapsePositioning']); updateUI(); });
 
   $('op-name').addEventListener('change', async (e: any) => {
@@ -469,6 +490,63 @@ function updateEditorUI() {
   if (chevron) chevron.textContent = config.collapseEditor ? '▸' : '▾';
 }
 
+function updateColorFilterUI() {
+  const section = $('op-color-filter-section') as HTMLDivElement;
+  const body = $('op-color-filter-body') as HTMLDivElement;
+  const list = $('op-color-filter-list') as HTMLDivElement;
+  const chevron = $('op-collapse-color-filter');
+  const ov = getActiveOverlay();
+
+  if (!ov || !ov.imageBase64 || !ov.colorCounts) {
+    section.style.display = 'none';
+    return;
+  }
+
+  section.style.display = 'flex';
+  if (body) body.style.display = config.collapseColorFilter ? 'none' : 'block';
+  if (chevron) chevron.textContent = config.collapseColorFilter ? '▸' : '▾';
+
+  list.innerHTML = '';
+  const hidden = new Set(ov.hiddenColors || []);
+  const entries = Object.entries(ov.colorCounts).sort((a, b) => b[1] - a[1]);
+  for (const [key, count] of entries) {
+    const row = document.createElement('div');
+    row.className = 'op-color-row';
+
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = !hidden.has(key);
+    cb.addEventListener('change', async () => {
+      if (!ov.hiddenColors) ov.hiddenColors = [];
+      if (cb.checked) {
+        ov.hiddenColors = ov.hiddenColors.filter(c => c !== key);
+      } else {
+        if (!ov.hiddenColors.includes(key)) ov.hiddenColors.push(key);
+      }
+      await saveConfig(['overlays']);
+      clearOverlayCache();
+      ensureHook();
+    });
+
+    const swatch = document.createElement('div');
+    swatch.className = 'op-color-swatch';
+    swatch.style.background = keyToHex(key);
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'op-color-name';
+    nameSpan.textContent = keyToName(key);
+
+    const countSpan = document.createElement('span');
+    countSpan.textContent = String(count);
+
+    row.appendChild(cb);
+    row.appendChild(swatch);
+    row.appendChild(nameSpan);
+    row.appendChild(countSpan);
+    list.appendChild(row);
+  }
+}
+
 export function updateUI() {
   if (!panelEl) return;
 
@@ -549,6 +627,7 @@ export function updateUI() {
 
   rebuildOverlayListUI();
   updateEditorUI();
+  updateColorFilterUI();
 
   const exportBtn = $('op-export-overlay') as HTMLButtonElement;
   const ov = getActiveOverlay();

--- a/src/ui/rsModal.ts
+++ b/src/ui/rsModal.ts
@@ -5,6 +5,7 @@ import { MAX_OVERLAY_DIM } from '../core/constants';
 import { ensureHook } from '../core/hook';
 import { clearOverlayCache } from '../core/cache';
 import { showToast } from '../core/toast';
+import { analyzeImageColors } from '../core/colorFilter';
 
 // dispatch when an overlay image is updated
 function emitOverlayChanged() {
@@ -764,6 +765,8 @@ export function buildRSModal() {
         rs!.ov.imageBase64 = dataUrl;
         rs!.ov.imageUrl = null;
         rs!.ov.isLocal = true;
+        rs!.ov.colorCounts = await analyzeImageColors(dataUrl);
+        rs!.ov.hiddenColors = [];
         await saveConfig(['overlays']);
         clearOverlayCache();
         ensureHook();
@@ -963,6 +966,8 @@ async function resizeOverlayImage(ov: any, targetW: number, targetH: number) {
   ov.imageBase64 = dataUrl;
   ov.imageUrl = null;
   ov.isLocal = true;
+  ov.colorCounts = await analyzeImageColors(dataUrl);
+  ov.hiddenColors = [];
   await saveConfig(['overlays']);
   clearOverlayCache();
   ensureHook();

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -68,6 +68,11 @@ export function injectStyles() {
 
       .op-list { display: flex; flex-direction: column; gap: 6px; height: 100%; overflow: auto; border: 1px solid var(--op-border); padding: 6px; border-radius: 10px; background: var(--op-bg); }
 
+      .op-color-list { display: flex; flex-direction: column; gap: 4px; max-height: 160px; overflow: auto; }
+      .op-color-row { display: flex; align-items: center; gap: 6px; }
+      .op-color-swatch { width: 16px; height: 16px; border: 1px solid var(--op-border); border-radius: 4px; }
+      .op-color-name { flex: 1; }
+
       .op-item { display: flex; align-items: center; gap: 6px; padding: 6px; border-radius: 8px; border: 1px solid var(--op-border); background: var(--op-subtle); }
       .op-item.active { outline: 2px solid color-mix(in oklab, var(--op-accent) 35%, transparent); background: var(--op-bg); }
       .op-item-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }


### PR DESCRIPTION
## Summary
- add utilities to compute color counts and names for overlay images
- show per-color checkboxes to filter overlay pixels
- support hiding selected colors during overlay rendering

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3800c7cd4832d805ad00dce80adba