### PR TITLE
feat: show color progress for overlays

### DIFF
--- a/src/core/colorFilter.ts
+++ b/src/core/colorFilter.ts
@@ -1,4 +1,6 @@
 import { createCanvas, loadImage } from './canvas';
+import { TILE_SIZE } from './constants';
+import { extractPixelCoords } from './overlay';
 import type { OverlayItem } from './store';
 
 export function rgbKeyToHex(key: string): string {
@@ -17,17 +19,90 @@ export async function updateOverlayColorStats(ov: OverlayItem) {
   const canvas = createCanvas(img.width, img.height) as HTMLCanvasElement;
   const ctx = canvas.getContext('2d', { willReadFrequently: true })!;
   ctx.drawImage(img, 0, 0);
-  const data = ctx.getImageData(0,0,img.width,img.height).data;
-  const stats: Record<string, number> = {};
-  for (let i=0;i<data.length;i+=4) {
-    const a = data[i+3];
-    if (a === 0) continue;
-    const r = data[i], g = data[i+1], b = data[i+2];
-    // Skip #deface transparency color
-    if (r === 0xde && g === 0xfa && b === 0xce) continue;
-    const key = `${r},${g},${b}`;
-    stats[key] = (stats[key]||0)+1;
+  const wImg = img.width, hImg = img.height;
+  const id = ctx.getImageData(0, 0, wImg, hImg);
+  const data = id.data;
+
+  const stats: Record<string, { total: number; remaining: number }> = {};
+
+  const base = ov.pixelUrl ? extractPixelCoords(ov.pixelUrl) : null;
+  const neededTiles = new Set<string>();
+
+  // First pass – count total pixels and gather tiles
+  for (let y = 0; y < hImg; y++) {
+    for (let x = 0; x < wImg; x++) {
+      const idx = (y * wImg + x) * 4;
+      const a = data[idx + 3];
+      if (a === 0) continue;
+      const r = data[idx], g = data[idx + 1], b = data[idx + 2];
+      // Skip #deface transparency color
+      if (r === 0xde && g === 0xfa && b === 0xce) continue;
+      const key = `${r},${g},${b}`;
+      const stat = stats[key] || { total: 0, remaining: 0 };
+      stat.total++;
+      stats[key] = stat;
+
+      if (base) {
+        const gx = base.posX + ov.offsetX + x;
+        const gy = base.posY + ov.offsetY + y;
+        const tx = base.chunk1 + Math.floor(gx / TILE_SIZE);
+        const ty = base.chunk2 + Math.floor(gy / TILE_SIZE);
+        neededTiles.add(`${tx},${ty}`);
+      }
+    }
   }
+
+  if (base) {
+    const tileCache = new Map<string, Uint8ClampedArray>();
+    const tilePromises = Array.from(neededTiles).map(async key => {
+      const [tx, ty] = key.split(',').map(n => parseInt(n, 10));
+      try {
+        const url = `https://backend.wplace.live/files/s0/tiles/${tx}/${ty}.png`;
+        const tileImg = await loadImage(url);
+        const tileCanvas = createCanvas(tileImg.width, tileImg.height) as HTMLCanvasElement;
+        const tctx = tileCanvas.getContext('2d', { willReadFrequently: true })!;
+        tctx.drawImage(tileImg, 0, 0);
+        const tdata = tctx.getImageData(0, 0, tileImg.width, tileImg.height).data;
+        tileCache.set(key, tdata);
+      } catch (e) {
+        console.warn('Overlay Pro: failed to load tile', key, e);
+      }
+    });
+    await Promise.all(tilePromises);
+
+    // Second pass – compute remaining pixels
+    for (let y = 0; y < hImg; y++) {
+      for (let x = 0; x < wImg; x++) {
+        const idx = (y * wImg + x) * 4;
+        const a = data[idx + 3];
+        if (a === 0) continue;
+        const r = data[idx], g = data[idx + 1], b = data[idx + 2];
+        if (r === 0xde && g === 0xfa && b === 0xce) continue;
+        const key = `${r},${g},${b}`;
+
+        const gx = base.posX + ov.offsetX + x;
+        const gy = base.posY + ov.offsetY + y;
+        const tx = base.chunk1 + Math.floor(gx / TILE_SIZE);
+        const ty = base.chunk2 + Math.floor(gy / TILE_SIZE);
+        const tileKey = `${tx},${ty}`;
+        const tdata = tileCache.get(tileKey);
+
+        let mismatch = true;
+        if (tdata) {
+          const px = ((gx % TILE_SIZE) + TILE_SIZE) % TILE_SIZE;
+          const py = ((gy % TILE_SIZE) + TILE_SIZE) % TILE_SIZE;
+          const tidx = (py * TILE_SIZE + px) * 4;
+          const tr = tdata[tidx], tg = tdata[tidx + 1], tb = tdata[tidx + 2];
+          if (r === tr && g === tg && b === tb) mismatch = false;
+        }
+        if (mismatch) stats[key].remaining++;
+      }
+    }
+  } else {
+    // No anchor set – everything is considered remaining
+    for (const key of Object.keys(stats)) stats[key].remaining = stats[key].total;
+  }
+
   ov.colorStats = stats;
   const filter: Record<string, boolean> = {};
   for (const k of Object.keys(stats)) filter[k] = true;

--- a/src/core/colorFilter.ts
+++ b/src/core/colorFilter.ts
@@ -53,6 +53,7 @@ export async function updateOverlayColorStats(ov: OverlayItem) {
   }
 
   if (base) {
+    ov.tileKeys = Array.from(neededTiles);
     const tileCache = new Map<string, Uint8ClampedArray>();
     const tilePromises = Array.from(neededTiles).map(async key => {
       const [tx, ty] = key.split(',').map(n => parseInt(n, 10));
@@ -99,6 +100,7 @@ export async function updateOverlayColorStats(ov: OverlayItem) {
       }
     }
   } else {
+    ov.tileKeys = undefined;
     // No anchor set – everything is considered remaining
     for (const key of Object.keys(stats)) stats[key].remaining = stats[key].total;
   }

--- a/src/core/colorFilter.ts
+++ b/src/core/colorFilter.ts
@@ -104,7 +104,15 @@ export async function updateOverlayColorStats(ov: OverlayItem) {
   }
 
   ov.colorStats = stats;
-  const filter: Record<string, boolean> = {};
-  for (const k of Object.keys(stats)) filter[k] = true;
+
+  const filter = ov.colorFilter || {} as Record<string, boolean>;
+  // Remove colors no longer present
+  for (const k of Object.keys(filter)) {
+    if (!(k in stats)) delete filter[k];
+  }
+  // Ensure all colors default to true
+  for (const k of Object.keys(stats)) {
+    if (!(k in filter)) filter[k] = true;
+  }
   ov.colorFilter = filter;
 }

--- a/src/core/hook.ts
+++ b/src/core/hook.ts
@@ -10,6 +10,7 @@ import { updateOverlayColorStats } from './colorFilter';
 let hookInstalled = false;
 let updateUICallback: null | (() => void) = null;
 const page: any = unsafeWindow;
+let tileUpdateTimeout: number | null = null;
 
 export function setUpdateUI(cb: () => void) {
   updateUICallback = cb;
@@ -88,6 +89,24 @@ export function attachHook() {
     if (pixelMatch) {
       const c = extractPixelCoords(pixelMatch.normalized);
       updatePixelCoords(c.chunk1, c.chunk2, c.posX, c.posY);
+    }
+
+    const tileMatch = urlStr.match(/backend\.wplace\.live\/files\/s0\/tiles\/(\d+)\/(\d+)\.png/);
+    if (tileMatch) {
+      const tx = tileMatch[1];
+      const ty = tileMatch[2];
+      const ov = getActiveOverlay();
+      if (ov && ov.tileKeys && ov.tileKeys.includes(`${tx},${ty}`)) {
+        if (tileUpdateTimeout) clearTimeout(tileUpdateTimeout);
+        tileUpdateTimeout = setTimeout(async () => {
+          const cur = getActiveOverlay();
+          if (cur) {
+            await updateOverlayColorStats(cur);
+            await saveConfig(['overlays']);
+            updateUI();
+          }
+        }, 1000);
+      }
     }
 
     // Anchor auto-capture: watch pixel endpoint, then store/normalize

--- a/src/core/hook.ts
+++ b/src/core/hook.ts
@@ -1,10 +1,11 @@
 /// <reference types="tampermonkey" />
-import { config, me, saveConfig } from './store';
+import { config, me, saveConfig, getActiveOverlay } from './store';
 import { matchPixelUrl, extractPixelCoords, matchMeUrl, updateOverlays } from './overlay';
 import { emit, EV_ANCHOR_SET, EV_AUTOCAP_CHANGED } from './events';
 import { updateUI } from '../ui/panel';
 import { type Map } from 'maplibre-gl';
 import { updatePixelCoords } from '../ui/coordDisplay';
+import { updateOverlayColorStats } from './colorFilter';
 
 let hookInstalled = false;
 let updateUICallback: null | (() => void) = null;
@@ -57,9 +58,20 @@ export function attachHook() {
         if (!ct.includes('application/json')) return response;
 
         const json = await response.json();
+        const prevPixels = typeof me.data?.pixelsPainted === 'number' ? me.data.pixelsPainted : null;
         me.data = json;
 
         updateUI();
+
+        if (prevPixels !== null && json.pixelsPainted > prevPixels) {
+          const ov = getActiveOverlay();
+          if (ov && ov.colorStats) {
+            updateOverlayColorStats(ov).then(async () => {
+              await saveConfig(['overlays']);
+              updateUI();
+            });
+          }
+        }
 
         return new Response(new Blob([JSON.stringify(json)]), {
           status: response.status,

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -14,7 +14,7 @@ export type OverlayItem = {
   offsetX: number;
   offsetY: number;
   opacity: number;
-  colorStats?: Record<string, number>;
+  colorStats?: Record<string, { total: number; remaining: number }>;
   colorFilter?: Record<string, boolean>;
 };
 

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -16,6 +16,7 @@ export type OverlayItem = {
   opacity: number;
   colorStats?: Record<string, { total: number; remaining: number }>;
   colorFilter?: Record<string, boolean>;
+  tileKeys?: string[];
 };
 
 export type Config = {

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -118,6 +118,7 @@ export function createUI() {
           <div class="op-section-title">
             <div class="op-title-left">
               <span class="op-title-text">Color filtering</span>
+              <span class="op-small-text" id="op-color-progress-total" style="margin-left:4px;"></span>
             </div>
             <div class="op-title-right">
               <button class="op-chevron" id="op-collapse-color-filter" title="Collapse/Expand">▾</button>
@@ -570,9 +571,11 @@ function rebuildColorFilterUI() {
   const container = document.getElementById('op-color-filter') as HTMLDivElement;
   if (!container) return;
   const ov = getActiveOverlay();
-  if (!ov || !ov.imageBase64) { container.style.display = 'none'; container.innerHTML = ''; return; }
+  const progressEl = document.getElementById('op-color-progress-total');
+  if (!ov || !ov.imageBase64) { if(progressEl) progressEl.textContent=''; container.style.display = 'none'; container.innerHTML = ''; return; }
   if (!ov.colorStats) {
     container.textContent = 'Analyzing colors…';
+    if(progressEl) progressEl.textContent = '';
     updateOverlayColorStats(ov).then(async () => { await saveConfig(['overlays']); clearOverlayCache(); await updateOverlays(); rebuildColorFilterUI(); });
     return;
   }
@@ -580,6 +583,7 @@ function rebuildColorFilterUI() {
   const stats = ov.colorStats;
   const filter = ov.colorFilter || {};
   const entries = Object.entries(stats).sort((a,b) => b[1].total - a[1].total);
+  let total = 0; let remaining = 0;
   for (const [key,stat] of entries) {
     const hex = rgbKeyToHex(key);
     const name = WPLACE_NAMES[key] || hex;
@@ -595,8 +599,11 @@ function rebuildColorFilterUI() {
       await updateOverlays();
     });
     container.appendChild(row);
+    total += stat.total;
+    remaining += stat.remaining;
   }
   container.style.display = 'flex';
+  if (progressEl) progressEl.textContent = `${remaining}/${total}`;
 }
 
 export function updateThemeToggle() {

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -579,13 +579,13 @@ function rebuildColorFilterUI() {
   container.innerHTML = '';
   const stats = ov.colorStats;
   const filter = ov.colorFilter || {};
-  const entries = Object.entries(stats).sort((a,b) => b[1]-a[1]);
-  for (const [key,count] of entries) {
+  const entries = Object.entries(stats).sort((a,b) => b[1].total - a[1].total);
+  for (const [key,stat] of entries) {
     const hex = rgbKeyToHex(key);
     const name = WPLACE_NAMES[key] || hex;
     const row = document.createElement('div');
     row.className = 'op-color-row';
-    row.innerHTML = `<input type="checkbox" ${filter[key]!==false?'checked':''}/><span class="op-color-swatch" style="background:${hex}"></span><span class="op-color-name">${name}</span><span class="op-color-count">${count}</span>`;
+    row.innerHTML = `<input type="checkbox" ${filter[key]!==false?'checked':''}/><span class="op-color-swatch" style="background:${hex}"></span><span class="op-color-name">${name}</span><span class="op-color-count">${stat.remaining}/${stat.total}</span>`;
     const checkbox = row.querySelector('input') as HTMLInputElement;
     checkbox.addEventListener('change', async () => {
       if (!ov.colorFilter) ov.colorFilter = {};


### PR DESCRIPTION
## Summary
- compute remaining vs total pixels per color by sampling wplace tiles
- display `${remaining}/${total}` progress in color filter UI
- track per-color totals in config store

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a996a9edc0832daaaa307df9f24fd9