### PR TITLE
feat: add jump button for overlays

### DIFF
--- a/src/core/hook.ts
+++ b/src/core/hook.ts
@@ -16,6 +16,8 @@ type Map = {
   addLayer(layer: any, beforeId?: string): void;
   setPaintProperty(layerId: string, name: string, value: any): void;
   moveLayer(id: string, beforeId?: string): void;
+  cameraForBounds?(bounds: any, options?: any): any;
+  flyTo?(options: any): void;
 };
 
 let hookInstalled = false;

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -1,3 +1,5 @@
+import { TILE_SIZE } from './constants';
+
 export function uid() {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2,10)}`;
 }
@@ -8,4 +10,30 @@ export function uniqueName(base: string, existing: string[]) {
   let i = 1;
   while (names.has(`${base} (${i})`.toLowerCase())) i++;
   return `${base} (${i})`;
+}
+
+const a = 2 * Math.PI * 6378137 / 2;
+const b = (a / TILE_SIZE) / 2 ** 10;
+
+export function pixelToLonLat(x: number, y: number): [number, number] {
+  const lon = (x * b - a) / a * 180;
+  let lat = (a - y * b) / a * 180;
+  lat = 180 / Math.PI * (2 * Math.atan(Math.exp(lat * Math.PI / 180)) - Math.PI / 2);
+  return [lon, lat];
+}
+
+export function lonLatToPixel(lon: number, lat: number) {
+  lat = Math.log(Math.tan((90 + lat) * Math.PI / 360)) / (Math.PI / 180);
+  const x = (lon / 180 * a + a) / b;
+  const y = (a - lat / 180 * a) / b;
+  return [Math.floor(x), Math.floor(y)];
+}
+
+export function selectPixel(x: number, y: number, zoom: number) {
+  const lonLat = pixelToLonLat(x + 0.5, y + 0.5);
+  unsafeWindow.localStorage.setItem('location', JSON.stringify({
+    lng: lonLat[0],
+    lat: lonLat[1],
+    zoom
+  }));
 }

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -3,8 +3,10 @@ import { config, me, saveConfig, getActiveOverlay, applyTheme, type OverlayItem 
 import { clearOverlayCache } from '../core/cache';
 import { showToast } from '../core/toast';
 import { urlToDataURL, fileToDataURL, gmFetchJson } from '../core/gm';
-import { uniqueName, uid } from '../core/util';
-import { extractPixelCoords, updateOverlays } from '../core/overlay';
+import { uniqueName, uid, pixelToLonLat, selectPixel } from '../core/util';
+import { extractPixelCoords, updateOverlays, decodeOverlayImage } from '../core/overlay';
+import { map } from '../core/hook';
+import { TILE_SIZE } from '../core/constants';
 import { buildCCModal, openCCModal } from './ccModal';
 import { buildRSModal, openRSModal } from './rsModal';
 import { EV_ANCHOR_SET, EV_AUTOCAP_CHANGED } from '../core/events';
@@ -220,15 +222,37 @@ function rebuildOverlayListUI() {
         <input type="radio" name="op-active" ${ov.id === config.activeOverlayId ? 'checked' : ''} title="Set active"/>
         <input type="checkbox" ${ov.enabled ? 'checked' : ''} title="Toggle enabled"/>
         <div class="op-item-name" title="${(ov.name || '(unnamed)') + localTag}">${(ov.name || '(unnamed)') + localTag}</div>
+        <button class="op-button" title="Jump to location">Jump</button>
         <button class="op-icon-btn" title="Delete overlay">🗑️</button>
     `;
-    const [radio, checkbox, nameDiv, trashBtn] = item.children as any as [HTMLInputElement, HTMLInputElement, HTMLDivElement, HTMLButtonElement];
+    const [radio, checkbox, nameDiv, jumpBtn, trashBtn] = item.children as any as [HTMLInputElement, HTMLInputElement, HTMLDivElement, HTMLButtonElement, HTMLButtonElement];
     radio.addEventListener('change', async () => { config.activeOverlayId = ov.id; await saveConfig(['activeOverlayId']); updateUI(); });
     checkbox.addEventListener('change', async () => {
       ov.enabled = checkbox.checked; await saveConfig(['overlays']); clearOverlayCache(); updateUI();
       await updateOverlays();
     });
     nameDiv.addEventListener('click', async () => { config.activeOverlayId = ov.id; await saveConfig(['activeOverlayId']); updateUI(); });
+    jumpBtn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      const m = map;
+      if (!m || !ov.pixelUrl || !ov.imageBase64) return;
+      const img = await decodeOverlayImage(ov.imageBase64);
+      if (!img) return;
+      const base = extractPixelCoords(ov.pixelUrl);
+      const x = base.chunk1 * TILE_SIZE + base.posX + ov.offsetX;
+      const y = base.chunk2 * TILE_SIZE + base.posY + ov.offsetY;
+      const camera = m.cameraForBounds([
+        pixelToLonLat(x, y),
+        pixelToLonLat(x + img.width, y + img.height)
+      ], {
+        padding: { top: 40, bottom: 12 + 133 + 40, right: 40, left: 40 }
+      });
+      camera.zoom = Math.max(camera.zoom, 11);
+      camera.bearing = null;
+      selectPixel(x, y, camera.zoom);
+      m.flyTo(camera);
+      updateUI();
+    });
     trashBtn.addEventListener('click', async (e) => {
       e.stopPropagation();
       if (!confirm(`Delete overlay "${ov.name || '(unnamed)'}"?`)) return;


### PR DESCRIPTION
## Summary
- add "Jump" option next to each overlay allowing quick navigation to its position
- support map camera movement and pixel selection utilities
- extend map typing to include camera functions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a9aecb633c832d9257ba3f9454058c