### PR TITLE
Update overlay stats after repositioning

### DIFF
--- a/src/core/hook.ts
+++ b/src/core/hook.ts
@@ -130,6 +130,7 @@ export function attachHook() {
         if (changed) {
           ov.pixelUrl = pixelMatch.normalized;
           ov.offsetX = 0; ov.offsetY = 0;
+          await updateOverlayColorStats(ov);
           await saveConfig(['overlays']);
 
           // turn off autocapture and notify UI (via events)

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -458,6 +458,7 @@ function addEventListeners(panel: HTMLDivElement) {
   const nudge = async (dx: number, dy: number) => {
     const ov = getActiveOverlay(); if (!ov) return;
     ov.offsetX += dx; ov.offsetY += dy;
+    await updateOverlayColorStats(ov);
     await saveConfig(['overlays']); clearOverlayCache(); updateUI();
     await updateOverlays();
   };


### PR DESCRIPTION
## Summary
- Recompute overlay stats and tile coverage when anchor pixel is captured
- Update stats and tile keys after nudging overlay position

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9b9cde578832d8db8a9edd222c8f3