### PR TITLE
Fix overlay tile tracking across multiple tiles

### DIFF
--- a/src/core/colorFilter.ts
+++ b/src/core/colorFilter.ts
@@ -3,6 +3,23 @@ import { TILE_SIZE } from './constants';
 import { extractPixelCoords } from './overlay';
 import type { OverlayItem } from './store';
 
+const overlayTileCache = new Map<string, Map<string, Uint8ClampedArray>>();
+const overlayDirtyTiles = new Map<string, Set<string>>();
+
+export function markTileDirty(overlayId: string, tileKey: string) {
+  let set = overlayDirtyTiles.get(overlayId);
+  if (!set) {
+    set = new Set();
+    overlayDirtyTiles.set(overlayId, set);
+  }
+  set.add(tileKey);
+}
+
+export function clearOverlayTileCache(overlayId: string) {
+  overlayTileCache.delete(overlayId);
+  overlayDirtyTiles.delete(overlayId);
+}
+
 export function rgbKeyToHex(key: string): string {
   const [r,g,b] = key.split(',').map(n => parseInt(n,10));
   const toHex = (n: number) => n.toString(16).padStart(2,'0');
@@ -54,8 +71,11 @@ export async function updateOverlayColorStats(ov: OverlayItem) {
 
   if (base) {
     ov.tileKeys = Array.from(neededTiles);
-    const tileCache = new Map<string, Uint8ClampedArray>();
+    const tileCache = overlayTileCache.get(ov.id) || new Map<string, Uint8ClampedArray>();
+    const dirty = overlayDirtyTiles.get(ov.id) || new Set<string>();
+
     const tilePromises = Array.from(neededTiles).map(async key => {
+      if (!dirty.has(key) && tileCache.has(key)) return;
       const [tx, ty] = key.split(',').map(n => parseInt(n, 10));
       try {
         const url = `https://backend.wplace.live/files/s0/tiles/${tx}/${ty}.png`;
@@ -67,9 +87,16 @@ export async function updateOverlayColorStats(ov: OverlayItem) {
         tileCache.set(key, tdata);
       } catch (e) {
         console.warn('Overlay Pro: failed to load tile', key, e);
+      } finally {
+        dirty.delete(key);
       }
     });
     await Promise.all(tilePromises);
+    overlayTileCache.set(ov.id, tileCache);
+    if (dirty.size > 0) overlayDirtyTiles.set(ov.id, dirty); else overlayDirtyTiles.delete(ov.id);
+    for (const key of Array.from(tileCache.keys())) {
+      if (!neededTiles.has(key)) tileCache.delete(key);
+    }
 
     // Second pass – compute remaining pixels
     for (let y = 0; y < hImg; y++) {

--- a/src/core/hook.ts
+++ b/src/core/hook.ts
@@ -4,7 +4,7 @@ import { matchPixelUrl, extractPixelCoords, matchMeUrl, updateOverlays } from '.
 import { emit, EV_ANCHOR_SET, EV_AUTOCAP_CHANGED } from './events';
 import { updateUI } from '../ui/panel';
 import { updatePixelCoords } from '../ui/coordDisplay';
-import { updateOverlayColorStats } from './colorFilter';
+import { updateOverlayColorStats, markTileDirty, clearOverlayTileCache } from './colorFilter';
 
 // Minimal map type to avoid bundling maplibre-gl
 type Map = {
@@ -23,7 +23,6 @@ type Map = {
 let hookInstalled = false;
 let updateUICallback: null | (() => void) = null;
 const page: any = unsafeWindow;
-let tileUpdateTimeout: number | null = null;
 
 export function setUpdateUI(cb: () => void) {
   updateUICallback = cb;
@@ -110,15 +109,7 @@ export function attachHook() {
       const ty = tileMatch[2];
       const ov = getActiveOverlay();
       if (ov && ov.tileKeys && ov.tileKeys.includes(`${tx},${ty}`)) {
-        if (tileUpdateTimeout) clearTimeout(tileUpdateTimeout);
-        tileUpdateTimeout = setTimeout(async () => {
-          const cur = getActiveOverlay();
-          if (cur) {
-            await updateOverlayColorStats(cur);
-            await saveConfig(['overlays']);
-            updateUI();
-          }
-        }, 1000);
+        markTileDirty(ov.id, `${tx},${ty}`);
       }
     }
 
@@ -130,6 +121,8 @@ export function attachHook() {
         if (changed) {
           ov.pixelUrl = pixelMatch.normalized;
           ov.offsetX = 0; ov.offsetY = 0;
+          clearOverlayTileCache(ov.id);
+          await updateOverlayColorStats(ov);
           await saveConfig(['overlays']);
 
           // turn off autocapture and notify UI (via events)

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -10,7 +10,7 @@ import { TILE_SIZE } from '../core/constants';
 import { buildCCModal, openCCModal } from './ccModal';
 import { buildRSModal, openRSModal } from './rsModal';
 import { EV_ANCHOR_SET, EV_AUTOCAP_CHANGED } from '../core/events';
-import { updateOverlayColorStats, rgbKeyToHex } from '../core/colorFilter';
+import { updateOverlayColorStats, rgbKeyToHex, clearOverlayTileCache } from '../core/colorFilter';
 import { WPLACE_NAMES } from '../core/palette';
 
 let panelEl: HTMLDivElement | null = null;
@@ -455,11 +455,19 @@ function addEventListeners(panel: HTMLDivElement) {
     try { await setOverlayImageFromFile(ov, file); } catch (err) { console.error(err); alert('Failed to load dropped image.'); }
   });
 
-  const nudge = async (dx: number, dy: number) => {
+  let nudgeTimeout: number | null = null;
+  const nudge = (dx: number, dy: number) => {
     const ov = getActiveOverlay(); if (!ov) return;
     ov.offsetX += dx; ov.offsetY += dy;
-    await saveConfig(['overlays']); clearOverlayCache(); updateUI();
-    await updateOverlays();
+    clearOverlayTileCache(ov.id);
+    if (nudgeTimeout) window.clearTimeout(nudgeTimeout);
+    nudgeTimeout = window.setTimeout(async () => {
+      const cur = getActiveOverlay(); if (!cur) return;
+      await updateOverlayColorStats(cur);
+      await saveConfig(['overlays']);
+      clearOverlayCache(); updateUI();
+      await updateOverlays();
+    }, 300);
   };
   $('op-nudge-up').addEventListener('click', () => nudge(0, -1));
   $('op-nudge-down').addEventListener('click', () => nudge(0, 1));


### PR DESCRIPTION
## Summary
- Cache overlay tiles and track dirty tiles so only changed tiles are re-fetched
- Debounce overlay nudges and clear tile cache on reposition
- Mark overlay tiles as dirty when served and reset cache after anchor capture

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9b9cde578832d8db8a9edd222c8f3